### PR TITLE
make --user optional with smart defaults in pywrapper-install

### DIFF
--- a/src/rda_python_setuid/install.py
+++ b/src/rda_python_setuid/install.py
@@ -77,7 +77,7 @@ def main():
    )
    parser.add_argument(
       '--user', default=None,
-      help="User name to own the setuid binary (required unless --simple is used)"
+      help="User name to own the setuid binary (default: current login user for --pgstart, gdexdata otherwise)"
    )
    parser.add_argument(
       '--simple', action='store_true',
@@ -94,8 +94,12 @@ def main():
    )
    args = parser.parse_args()
 
-   if not args.simple and args.user is None:
-      parser.error("--user is required unless --simple is used")
+   if args.user is None and not args.simple:
+      import pwd
+      if args.pgstart:
+         args.user = pwd.getpwuid(os.getuid()).pw_name
+      else:
+         args.user = 'gdexdata'
 
    bindir = args.envhome or get_bindir()
    pywrapper = os.path.join(bindir, 'pywrapper')

--- a/src/rda_python_setuid/install.usg
+++ b/src/rda_python_setuid/install.usg
@@ -4,10 +4,11 @@
 
  Usage: pywrapper-install --user USER [--envhome BINDIR] [--pgstart | --link PROGRAM [--simple]]
 
-      - Option --user USER (required)
+      - Option --user USER
           The user name to own the setuid binary.  For Mode 1 (CommonUser program),
           this is the common user (e.g. gdexdata).  For Mode 2 (pgstart), this is
-          the specialist user (e.g. zji).
+          the specialist user (e.g. zji).  Defaults to 'gdexdata' unless --pgstart
+          is given, in which case it defaults to the current login user.
 
       - Option --envhome BINDIR
           Path to the venv bin/ directory.  Defaults to the bin/ directory of the


### PR DESCRIPTION
Default --user to current login user when --pgstart is given, and to 'gdexdata' otherwise.  --simple still requires no --user.  Update install.usg to document the new defaults.